### PR TITLE
Feature/slashing logic (#13)

### DIFF
--- a/packages/contracts/scripts/run-e2e.ts
+++ b/packages/contracts/scripts/run-e2e.ts
@@ -41,6 +41,7 @@ async function main() {
     await stakingManager.getAddress(),
     await disputeResolver.getAddress(),
     10 * 60, // 10 min challenge period
+    ethers.parseEther('0.1'), // The missing challenge bond
   ])
   await vortexVerifier.waitForDeployment()
 

--- a/packages/contracts/src/DisputeResolver.sol
+++ b/packages/contracts/src/DisputeResolver.sol
@@ -2,19 +2,23 @@
 pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
+import "./interfaces/IStakingManager.sol";
+import "./interfaces/IVortexVerifier.sol";
 
 contract DisputeResolver is Ownable {
     // --- Structs ---
     struct Dispute {
+        address proposer;
         uint256 yesVotes;
         uint256 noVotes;
         mapping(address => bool) hasVoted;
         bool resolved;
-        bool exists; // To differentiate from default struct values
+        bool exists;
     }
 
     // --- State Variables ---
     address public vortexVerifierAddress;
+    IStakingManager public stakingManager;
     mapping(address => bool) public isMember;
     mapping(bytes32 => Dispute) public disputes;
     uint256 public totalMembers;
@@ -23,8 +27,8 @@ contract DisputeResolver is Ownable {
     event MemberAdded(address indexed member);
     event MemberRemoved(address indexed member);
     event Voted(bytes32 indexed disputeId, address indexed voter, bool voteConfirm);
-    event DisputeResolved(bytes32 indexed disputeId, bool result);
-    event DisputeCreated(bytes32 indexed disputeId);
+    event DisputeResolved(bytes32 indexed disputeId, bool result, address indexed proposer);
+    event DisputeCreated(bytes32 indexed disputeId, address indexed proposer);
 
     // --- Modifiers ---
     modifier onlyVortexVerifier() {
@@ -41,18 +45,19 @@ contract DisputeResolver is Ownable {
 
     // --- External Functions ---
 
-    function setVortexVerifierAddress(address _address) external onlyOwner {
-        require(_address != address(0), "DisputeResolver: Zero address not allowed");
-        vortexVerifierAddress = _address;
+    function setAddresses(address _verifier, address _stakingManager) external onlyOwner {
+        require(_verifier != address(0) && _stakingManager != address(0), "DisputeResolver: Zero address");
+        vortexVerifierAddress = _verifier;
+        stakingManager = IStakingManager(_stakingManager);
     }
 
-    function createDispute(bytes32 disputeId) external onlyVortexVerifier {
+    function createDispute(bytes32 disputeId, address proposer) external onlyVortexVerifier {
         require(!disputes[disputeId].exists, "DisputeResolver: Dispute already exists");
         disputes[disputeId].exists = true;
-        emit DisputeCreated(disputeId);
+        disputes[disputeId].proposer = proposer;
+        emit DisputeCreated(disputeId, proposer);
     }
 
-    // --- Voting & Resolution ---
     function castVote(bytes32 disputeId, bool voteConfirm) public {
         require(isMember[msg.sender], "DisputeResolver: Caller is not a council member");
         Dispute storage dispute = disputes[disputeId];
@@ -76,23 +81,32 @@ contract DisputeResolver is Ownable {
         require(!dispute.resolved, "DisputeResolver: Dispute has already been resolved");
 
         uint256 majorityThreshold = (totalMembers / 2) + 1;
+        bool isFraud = false;
 
         if (dispute.yesVotes >= majorityThreshold) {
-            dispute.resolved = true;
-            emit DisputeResolved(disputeId, true); // Fraud confirmed
+            isFraud = true;
         } else if (dispute.noVotes >= majorityThreshold) {
-            dispute.resolved = true;
-            emit DisputeResolved(disputeId, false); // Fraud denied
+            isFraud = false;
         } else {
             revert("DisputeResolver: Majority threshold not reached");
+        }
+
+        dispute.resolved = true;
+        emit DisputeResolved(disputeId, isFraud, dispute.proposer);
+
+        // Finalize the challenge in the verifier (handles bond)
+        IVortexVerifier(vortexVerifierAddress).finalizeChallenge(disputeId, isFraud);
+
+        // Slash the proposer if fraud was confirmed
+        if (isFraud) {
+            stakingManager.slash(dispute.proposer);
         }
     }
 
     // --- View Functions ---
-
-    function getDispute(bytes32 disputeId) external view returns (uint256, uint256, bool, bool) {
+    function getDispute(bytes32 disputeId) external view returns (address, uint256, uint256, bool, bool) {
         Dispute storage d = disputes[disputeId];
-        return (d.yesVotes, d.noVotes, d.resolved, d.exists);
+        return (d.proposer, d.yesVotes, d.noVotes, d.resolved, d.exists);
     }
 
     // --- Membership Management ---

--- a/packages/contracts/src/VortexVerifier.sol
+++ b/packages/contracts/src/VortexVerifier.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.20;
 
 import "./interfaces/IStakingManager.sol";
+import "./interfaces/IVortexVerifier.sol";
 import "./DisputeResolver.sol";
 
 /**
@@ -12,23 +13,26 @@ import "./DisputeResolver.sol";
  * after the period has safely passed.
  * @dev All data proposed is considered valid unless challenged within the challenge period.
  */
-contract VortexVerifier {
+contract VortexVerifier is IVortexVerifier {
     /// @notice The address of the StakingManager contract, used to verify proposer stakes.
     IStakingManager public immutable stakingManager;
 
     /// @notice The address of the DisputeResolver contract, where challenges are sent.
-    DisputeResolver public immutable disputeResolver;
+    address public immutable disputeResolver;
 
     /// @notice The duration in seconds for the challenge period.
     uint256 public immutable challengePeriod;
+
+    /// @notice The amount of ETH required to be sent as a bond to challenge a proposal.
+    uint256 public immutable challengeBond;
 
     struct DataPayload {
         uint256 timestamp;
         bytes data;
     }
-
     struct Proposal {
         address proposer;
+        address challenger;
         uint256 proposedAt;
         DataPayload payload;
         bool isExecuted;
@@ -39,21 +43,29 @@ contract VortexVerifier {
 
     event DataProposed(bytes32 indexed dataId, address indexed proposer, DataPayload payload);
     event DataExecuted(bytes32 indexed dataId);
-    event DataChallenged(bytes32 indexed dataId, address indexed challenger);
+    event DataChallenged(bytes32 indexed dataId, address indexed challenger, uint256 bondAmount);
+    event ChallengeFinalized(bytes32 indexed dataId, bool indexed isFraud, address indexed challenger);
 
     modifier onlyStaker() {
         require(stakingManager.stakes(msg.sender) > 0, "VortexVerifier: Caller is not a staker");
         _;
     }
 
-    constructor(address _stakingManager, address _disputeResolver, uint256 _challengePeriod) {
+    modifier onlyDisputeResolver() {
+        require(msg.sender == disputeResolver, "VortexVerifier: Caller is not the DisputeResolver");
+        _;
+    }
+
+    constructor(address _stakingManager, address _disputeResolver, uint256 _challengePeriod, uint256 _challengeBond) {
         require(_stakingManager != address(0), "VortexVerifier: Invalid StakingManager address");
         require(_disputeResolver != address(0), "VortexVerifier: Invalid DisputeResolver address");
         require(_challengePeriod > 0, "VortexVerifier: Challenge period must be greater than 0");
+        require(_challengeBond > 0, "VortexVerifier: Challenge bond must be greater than 0");
         
         stakingManager = IStakingManager(_stakingManager);
-        disputeResolver = DisputeResolver(_disputeResolver);
+        disputeResolver = _disputeResolver;
         challengePeriod = _challengePeriod;
+        challengeBond = _challengeBond;
     }
 
     function proposeData(DataPayload calldata _payload) external onlyStaker returns (bytes32) {
@@ -61,6 +73,7 @@ contract VortexVerifier {
 
         proposedData[dataId] = Proposal({
             proposer: msg.sender,
+            challenger: address(0),
             proposedAt: block.timestamp,
             payload: _payload,
             isExecuted: false,
@@ -83,12 +96,8 @@ contract VortexVerifier {
         emit DataExecuted(_dataId);
     }
 
-    /**
-     * @notice Allows any user to challenge a proposed data payload within the challenge period.
-     * @dev This function marks the proposal as challenged, preventing its execution until the dispute is resolved.
-     * @param _dataId The unique ID of the data payload to challenge.
-     */
-    function challengeData(bytes32 _dataId) external {
+    function challengeData(bytes32 _dataId) external payable {
+        require(msg.value == challengeBond, "VortexVerifier: Challenge bond must be provided");
         Proposal storage proposal = proposedData[_dataId];
 
         require(proposal.proposer != address(0), "VortexVerifier: Proposal does not exist");
@@ -96,10 +105,24 @@ contract VortexVerifier {
         require(!proposal.isChallenged, "VortexVerifier: Proposal already challenged");
 
         proposal.isChallenged = true;
+        proposal.challenger = msg.sender;
         
-        // Initiate the dispute in the resolver contract
-        disputeResolver.createDispute(_dataId);
+        DisputeResolver(disputeResolver).createDispute(_dataId, proposal.proposer);
 
-        emit DataChallenged(_dataId, msg.sender);
+        emit DataChallenged(_dataId, msg.sender, msg.value);
+    }
+
+    function finalizeChallenge(bytes32 dataId, bool isFraud) external override onlyDisputeResolver {
+        Proposal storage proposal = proposedData[dataId];
+        require(proposal.challenger != address(0), "VortexVerifier: Challenge does not exist for this proposal");
+
+        if (isFraud) {
+            // Refund the bond to the successful challenger
+            (bool success, ) = proposal.challenger.call{value: challengeBond}("");
+            require(success, "VortexVerifier: Bond refund failed");
+        }
+        // If not fraud, the bond is forfeited and remains with the contract.
+
+        emit ChallengeFinalized(dataId, isFraud, proposal.challenger);
     }
 }

--- a/packages/contracts/src/interfaces/IStakingManager.sol
+++ b/packages/contracts/src/interfaces/IStakingManager.sol
@@ -14,4 +14,10 @@ interface IStakingManager {
      * @return The amount staked in wei.
      */
     function stakes(address user) external view returns (uint256);
+
+    /**
+     * @notice Slashes the stake of a given address.
+     * @param proposer The address of the user to slash.
+     */
+    function slash(address proposer) external;
 }

--- a/packages/contracts/src/interfaces/IVortexVerifier.sol
+++ b/packages/contracts/src/interfaces/IVortexVerifier.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IVortexVerifier {
+    function finalizeChallenge(bytes32 dataId, bool isFraud) external;
+}


### PR DESCRIPTION
* feat(contracts): implement on-chain happy path for Vortex protocol

Implements the foundational smart contracts required for the optimistic 'happy path' operation of the Vortex oracle, following strict TDD.

- Adds and refactors `StakingManager.sol` to manage validator staking, incorporating OpenZeppelin's ReentrancyGuard and full NatSpec documentation.
- Implements `VortexVerifier.sol` with core logic for `proposeData` and `executeIntent`, including a configurable challenge period.
- Establishes a clean interface-based architecture by creating `IStakingManager.sol`.
- Achieves 100% test coverage for all implemented logic, including edge cases, with a comprehensive Hardhat test suite.

This commit establishes a robust and secure on-chain backbone, enabling future development of the off-chain services and the dispute resolution mechanism.

* fix(tooling): correct linting errors and prettier config

-   Resolves TypeScript linting errors in `VortexVerifier.test.ts` related to unused imports and explicit 'any' type.
-   Renames `.prettierrc.js` to `.prettierrc.cjs` to fix module resolution issues caused by the root package's "type": "module" setting.
-   Formats all relevant files according to the updated prettier configuration.

* chore: include build artifacts

* fix(contracts): correct tsconfig to include typechain-types

* feat(contracts): implement slashing logic

Integrates DisputeResolver with StakingManager to enforce economic penalties. When a dispute is resolved and fraud is confirmed, the original proposer's stake is now slashed.

Changes:
- `StakingManager.sol`: Added a `slash(address)` function, callable only by the DisputeResolver.
- `IStakingManager.sol`: Updated the interface with the `slash` function.
- `DisputeResolver.sol`:
    - Now holds an address for the StakingManager.
    - `resolveDispute` now calls `stakingManager.slash()` upon fraud confirmation.
    - `Dispute` struct now stores the proposer's address.
- `VortexVerifier.sol`: `challengeData` now passes the proposer's address when creating a dispute.
- Tests: Updated `DisputeResolver.test.ts` and `VortexVerifier.test.ts` to reflect the new logic and verify the end-to-end slashing mechanism.

---
name: '🚀 Feature'
about: 'Propose a new feature or enhancement.'
---

## Description

_A clear and concise description of what this Pull Request does._

## Related Issue

_Closes #issue_number_

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Chore (e.g., refactoring, build process, dependency updates)

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce._

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
