### PR TITLE
Feature/slashing logic (#13)

### DIFF
--- a/packages/contracts/scripts/run-e2e.ts
+++ b/packages/contracts/scripts/run-e2e.ts
@@ -41,6 +41,7 @@ async function main() {
     await stakingManager.getAddress(),
     await disputeResolver.getAddress(),
     10 * 60, // 10 min challenge period
+    ethers.parseEther('0.1'), // The missing challenge bond
   ])
   await vortexVerifier.waitForDeployment()
 

--- a/packages/contracts/src/DisputeResolver.sol
+++ b/packages/contracts/src/DisputeResolver.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "./interfaces/IStakingManager.sol";
+import "./interfaces/IVortexVerifier.sol";
 
 contract DisputeResolver is Ownable {
     // --- Structs ---
@@ -93,6 +94,10 @@ contract DisputeResolver is Ownable {
         dispute.resolved = true;
         emit DisputeResolved(disputeId, isFraud, dispute.proposer);
 
+        // Finalize the challenge in the verifier (handles bond)
+        IVortexVerifier(vortexVerifierAddress).finalizeChallenge(disputeId, isFraud);
+
+        // Slash the proposer if fraud was confirmed
         if (isFraud) {
             stakingManager.slash(dispute.proposer);
         }

--- a/packages/contracts/src/interfaces/IVortexVerifier.sol
+++ b/packages/contracts/src/interfaces/IVortexVerifier.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IVortexVerifier {
+    function finalizeChallenge(bytes32 dataId, bool isFraud) external;
+}

--- a/packages/contracts/test/DisputeResolver.test.ts
+++ b/packages/contracts/test/DisputeResolver.test.ts
@@ -1,102 +1,121 @@
 import { loadFixture } from '@nomicfoundation/hardhat-toolbox/network-helpers'
 import { expect } from 'chai'
 import { ethers } from 'hardhat'
-import { keccak256, toUtf8Bytes } from 'ethers'
+import { EventLog } from 'ethers'
 import { HardhatEthersSigner } from '@nomicfoundation/hardhat-ethers/signers'
-import { DisputeResolver } from '../typechain-types'
+import { DisputeResolver, StakingManager, VortexVerifier } from '../typechain-types'
 
 describe('DisputeResolver', function () {
-  async function deployFullSystemFixture() {
-    const [owner, member1, member2, vortexVerifierSigner, proposer, otherAccount] =
-      await ethers.getSigners()
+  const CHALLENGE_PERIOD = 10 * 60 // 10 minutes
+  const CHALLENGE_BOND = ethers.parseEther('0.1')
 
+  // This fixture deploys the entire system and sets up all contract links
+  async function deployFullSystemFixture() {
+    const [owner, member1, member2, proposer, challenger, otherAccount] = await ethers.getSigners()
+
+    // Deploy StakingManager
     const StakingManagerFactory = await ethers.getContractFactory('StakingManager')
     const stakingManager = await StakingManagerFactory.deploy()
     await stakingManager.waitForDeployment()
 
+    // Deploy DisputeResolver
     const DisputeResolverFactory = await ethers.getContractFactory('DisputeResolver')
     const disputeResolver = await DisputeResolverFactory.deploy(owner.address)
     await disputeResolver.waitForDeployment()
 
-    // Configure connections
-    await disputeResolver.connect(owner).setAddresses(vortexVerifierSigner.address, await stakingManager.getAddress())
+    // Deploy VortexVerifier
+    const VortexVerifierFactory = await ethers.getContractFactory('VortexVerifier')
+    const vortexVerifier = await VortexVerifierFactory.deploy(
+      await stakingManager.getAddress(),
+      await disputeResolver.getAddress(),
+      CHALLENGE_PERIOD,
+      CHALLENGE_BOND,
+    )
+    await vortexVerifier.waitForDeployment()
+
+    // Configure connections between contracts
+    await disputeResolver
+      .connect(owner)
+      .setAddresses(await vortexVerifier.getAddress(), await stakingManager.getAddress())
     await stakingManager.connect(owner).setDisputeResolverAddress(await disputeResolver.getAddress())
 
-    // Setup council
+    // Setup council in DisputeResolver
     await disputeResolver.connect(owner).addMember(member1.address)
     await disputeResolver.connect(owner).addMember(member2.address)
 
+    // Proposer stakes 1 ETH to be eligible
+    const stakeAmount = ethers.parseEther('1')
+    await stakingManager.connect(proposer).stake({ value: stakeAmount })
+
     return {
+      vortexVerifier,
       disputeResolver,
       stakingManager,
       owner,
       member1,
       member2,
-      vortexVerifierSigner,
       proposer,
+      challenger,
       otherAccount,
     }
   }
 
-  async function createDispute(
-    disputeResolver: DisputeResolver,
-    disputeId: string,
+  // Helper to propose, challenge, and return the disputeId
+  async function fullChallengeCycle(
+    vortexVerifier: VortexVerifier,
     proposer: HardhatEthersSigner,
-    verifierSigner: HardhatEthersSigner,
+    challenger: HardhatEthersSigner,
   ) {
-    await disputeResolver.connect(verifierSigner).createDispute(disputeId, proposer.address)
+    const payload = { timestamp: Date.now(), data: ethers.toUtf8Bytes('fraudulent data') }
+    const tx = await vortexVerifier.connect(proposer).proposeData(payload)
+    const receipt = await tx.wait()
+    const event = receipt?.logs.find(
+      (e) => e instanceof EventLog && e.eventName === 'DataProposed',
+    ) as EventLog | undefined
+    const dataId = event?.args[0]
+
+    await vortexVerifier.connect(challenger).challengeData(dataId, { value: CHALLENGE_BOND })
+    return dataId
   }
 
   describe('Dispute Resolution Effects', function () {
-    it("Should slash the proposer's stake upon a 'fraud' resolution", async function () {
-      const {
-        disputeResolver,
-        stakingManager,
-        owner,
-        member1,
-        vortexVerifierSigner,
-        proposer,
-      } = await loadFixture(deployFullSystemFixture)
+    it("Should slash proposer and refund challenger's bond upon a 'fraud' resolution", async function () {
+      const { disputeResolver, stakingManager, vortexVerifier, owner, member1, proposer, challenger } =
+        await loadFixture(deployFullSystemFixture)
 
-      const stakeAmount = ethers.parseEther('1')
-      await stakingManager.connect(proposer).stake({ value: stakeAmount })
-      expect(await stakingManager.stakes(proposer.address)).to.equal(stakeAmount)
+      const stakeAmount = await stakingManager.stakes(proposer.address)
+      const disputeId = await fullChallengeCycle(vortexVerifier, proposer, challenger)
 
-      const disputeId = keccak256(toUtf8Bytes('fraud-proposal'))
-      await createDispute(disputeResolver, disputeId, proposer, vortexVerifierSigner)
-      
+      // Vote to confirm fraud
       await disputeResolver.connect(owner).castVote(disputeId, true)
       await disputeResolver.connect(member1).castVote(disputeId, true)
-      
-      await expect(disputeResolver.resolveDispute(disputeId))
-        .to.emit(stakingManager, 'Slashed')
-        .withArgs(proposer.address, stakeAmount)
 
+      // Expect the challenger's balance to increase by the bond amount upon resolution
+      await expect(disputeResolver.resolveDispute(disputeId)).to.changeEtherBalance(
+        challenger,
+        CHALLENGE_BOND,
+      )
+
+      // Expect the proposer to be slashed
       expect(await stakingManager.stakes(proposer.address)).to.equal(0)
     })
 
-    it("Should NOT slash the proposer's stake upon a 'no-fraud' resolution", async function () {
-        const {
-          disputeResolver,
-          stakingManager,
-          owner,
-          member1,
-          vortexVerifierSigner,
-          proposer,
-        } = await loadFixture(deployFullSystemFixture)
-  
-        const stakeAmount = ethers.parseEther('1')
-        await stakingManager.connect(proposer).stake({ value: stakeAmount })
-  
-        const disputeId = keccak256(toUtf8Bytes('no-fraud-proposal'))
-        await createDispute(disputeResolver, disputeId, proposer, vortexVerifierSigner)
-        
-        await disputeResolver.connect(owner).castVote(disputeId, false)
-        await disputeResolver.connect(member1).castVote(disputeId, false)
-        
-        await expect(disputeResolver.resolveDispute(disputeId)).to.not.emit(stakingManager, 'Slashed')
-  
-        expect(await stakingManager.stakes(proposer.address)).to.equal(stakeAmount)
-      })
+    it("Should NOT slash proposer and FORFEIT challenger's bond upon a 'no-fraud' resolution", async function () {
+      const { disputeResolver, stakingManager, vortexVerifier, owner, member1, proposer, challenger } =
+        await loadFixture(deployFullSystemFixture)
+
+      const stakeAmount = await stakingManager.stakes(proposer.address)
+      const disputeId = await fullChallengeCycle(vortexVerifier, proposer, challenger)
+
+      // Vote to confirm no fraud
+      await disputeResolver.connect(owner).castVote(disputeId, false)
+      await disputeResolver.connect(member1).castVote(disputeId, false)
+
+      // Expect the challenger's balance to NOT change (bond is forfeited)
+      await expect(disputeResolver.resolveDispute(disputeId)).to.changeEtherBalance(challenger, 0)
+
+      // Expect the proposer's stake to remain unchanged
+      expect(await stakingManager.stakes(proposer.address)).to.equal(stakeAmount)
+    })
   })
 })

--- a/packages/contracts/test/VortexVerifier.test.ts
+++ b/packages/contracts/test/VortexVerifier.test.ts
@@ -7,6 +7,7 @@ import { EventLog } from 'ethers'
 
 describe('VortexVerifier', function () {
   const CHALLENGE_PERIOD = 10 * 60 // 10 minutes
+  const CHALLENGE_BOND = ethers.parseEther('0.1') // Set a bond of 0.1 ETH
 
   // Define a type for our fixture
   type FixtureType = {
@@ -38,6 +39,7 @@ describe('VortexVerifier', function () {
       await stakingManager.getAddress(),
       await disputeResolver.getAddress(),
       CHALLENGE_PERIOD,
+      CHALLENGE_BOND, // Provide the bond value
     )
     await vortexVerifier.waitForDeployment()
 
@@ -74,12 +76,13 @@ describe('VortexVerifier', function () {
   }
 
   describe('Deployment', function () {
-    it('Should set the correct addresses and challenge period', async function () {
+    it('Should set the correct addresses, challenge period, and bond', async function () {
       const { vortexVerifier, stakingManager, disputeResolver } =
         await loadFixture(deployContractsFixture)
       expect(await vortexVerifier.stakingManager()).to.equal(await stakingManager.getAddress())
       expect(await vortexVerifier.disputeResolver()).to.equal(await disputeResolver.getAddress())
       expect(await vortexVerifier.challengePeriod()).to.equal(CHALLENGE_PERIOD)
+      expect(await vortexVerifier.challengeBond()).to.equal(CHALLENGE_BOND)
     })
   })
 
@@ -99,29 +102,41 @@ describe('VortexVerifier', function () {
     it('Should revert if trying to challenge data that does not exist', async function () {
       const { vortexVerifier, challenger } = fixture
       const fakeDataId = ethers.keccak256(ethers.toUtf8Bytes('non-existent'))
-      await expect(vortexVerifier.connect(challenger).challengeData(fakeDataId)).to.be.revertedWith(
-        'VortexVerifier: Proposal does not exist',
-      )
+      await expect(
+        vortexVerifier.connect(challenger).challengeData(fakeDataId, { value: CHALLENGE_BOND }),
+      ).to.be.revertedWith('VortexVerifier: Proposal does not exist')
     })
 
     it('Should revert if trying to challenge after the challenge period has ended', async function () {
       const { vortexVerifier, challenger } = fixture
       await time.increase(CHALLENGE_PERIOD + 1)
+      await expect(
+        vortexVerifier.connect(challenger).challengeData(dataId, { value: CHALLENGE_BOND }),
+      ).to.be.revertedWith('VortexVerifier: Challenge period has ended')
+    })
+
+    it('Should revert if the challenger does not provide the exact bond amount', async function () {
+      const { vortexVerifier, challenger } = fixture
+      // Attempt to challenge without sending any ETH
       await expect(vortexVerifier.connect(challenger).challengeData(dataId)).to.be.revertedWith(
-        'VortexVerifier: Challenge period has ended',
+        'VortexVerifier: Challenge bond must be provided',
       )
+      // Attempt to challenge with an incorrect bond amount
+      await expect(
+        vortexVerifier.connect(challenger).challengeData(dataId, { value: ethers.parseEther('0.05') }),
+      ).to.be.revertedWith('VortexVerifier: Challenge bond must be provided')
     })
 
-    it('Should allow a user to challenge a valid proposal', async function () {
+    it('Should allow a user to challenge a valid proposal with the correct bond', async function () {
       const { vortexVerifier, challenger } = fixture
-      await expect(vortexVerifier.connect(challenger).challengeData(dataId))
+      await expect(vortexVerifier.connect(challenger).challengeData(dataId, { value: CHALLENGE_BOND }))
         .to.emit(vortexVerifier, 'DataChallenged')
-        .withArgs(dataId, challenger.address)
+        .withArgs(dataId, challenger.address, CHALLENGE_BOND)
     })
 
-    it('Should set the isChallenged flag to true', async function () {
+    it('Should set the isChallenged flag to true on a successful challenge', async function () {
       const { vortexVerifier, challenger } = fixture
-      await vortexVerifier.connect(challenger).challengeData(dataId)
+      await vortexVerifier.connect(challenger).challengeData(dataId, { value: CHALLENGE_BOND })
       const proposal = await vortexVerifier.proposedData(dataId)
       expect(proposal.isChallenged).to.be.true
     })
@@ -130,7 +145,7 @@ describe('VortexVerifier', function () {
       const { vortexVerifier, disputeResolver, challenger } = fixture
       
       // Action: Challenge the data
-      await vortexVerifier.connect(challenger).challengeData(dataId)
+      await vortexVerifier.connect(challenger).challengeData(dataId, { value: CHALLENGE_BOND })
 
       // Assert: Check if the dispute was initialized in DisputeResolver
       const dispute = await disputeResolver.getDispute(dataId)
@@ -145,14 +160,16 @@ describe('VortexVerifier', function () {
 
     it('Should revert if trying to challenge an already challenged proposal', async function () {
       const { vortexVerifier, challenger } = fixture
-      await vortexVerifier.connect(challenger).challengeData(dataId) // First challenge
-      await expect(vortexVerifier.connect(challenger).challengeData(dataId)) // Second challenge
+      await vortexVerifier.connect(challenger).challengeData(dataId, { value: CHALLENGE_BOND }) // First challenge
+      await expect(
+        vortexVerifier.connect(challenger).challengeData(dataId, { value: CHALLENGE_BOND }),
+      ) // Second challenge
         .to.be.revertedWith('VortexVerifier: Proposal already challenged')
     })
 
     it('Should revert executeIntent for a challenged proposal', async function () {
       const { vortexVerifier, challenger } = fixture
-      await vortexVerifier.connect(challenger).challengeData(dataId)
+      await vortexVerifier.connect(challenger).challengeData(dataId, { value: CHALLENGE_BOND })
       await time.increase(CHALLENGE_PERIOD + 1) // Time passes
       await expect(vortexVerifier.executeIntent(dataId)).to.be.revertedWith(
         'VortexVerifier: Proposal is under challenge',


### PR DESCRIPTION
* feat(contracts): implement on-chain happy path for Vortex protocol

Implements the foundational smart contracts required for the optimistic 'happy path' operation of the Vortex oracle, following strict TDD.

- Adds and refactors `StakingManager.sol` to manage validator staking, incorporating OpenZeppelin's ReentrancyGuard and full NatSpec documentation.
- Implements `VortexVerifier.sol` with core logic for `proposeData` and `executeIntent`, including a configurable challenge period.
- Establishes a clean interface-based architecture by creating `IStakingManager.sol`.
- Achieves 100% test coverage for all implemented logic, including edge cases, with a comprehensive Hardhat test suite.

This commit establishes a robust and secure on-chain backbone, enabling future development of the off-chain services and the dispute resolution mechanism.

* fix(tooling): correct linting errors and prettier config

-   Resolves TypeScript linting errors in `VortexVerifier.test.ts` related to unused imports and explicit 'any' type.
-   Renames `.prettierrc.js` to `.prettierrc.cjs` to fix module resolution issues caused by the root package's "type": "module" setting.
-   Formats all relevant files according to the updated prettier configuration.

* chore: include build artifacts

* fix(contracts): correct tsconfig to include typechain-types

* feat(contracts): implement slashing logic

Integrates DisputeResolver with StakingManager to enforce economic penalties. When a dispute is resolved and fraud is confirmed, the original proposer's stake is now slashed.

Changes:
- `StakingManager.sol`: Added a `slash(address)` function, callable only by the DisputeResolver.
- `IStakingManager.sol`: Updated the interface with the `slash` function.
- `DisputeResolver.sol`:
    - Now holds an address for the StakingManager.
    - `resolveDispute` now calls `stakingManager.slash()` upon fraud confirmation.
    - `Dispute` struct now stores the proposer's address.
- `VortexVerifier.sol`: `challengeData` now passes the proposer's address when creating a dispute.
- Tests: Updated `DisputeResolver.test.ts` and `VortexVerifier.test.ts` to reflect the new logic and verify the end-to-end slashing mechanism.

---
name: '🚀 Feature'
about: 'Propose a new feature or enhancement.'
---

## Description

_A clear and concise description of what this Pull Request does._

## Related Issue

_Closes #issue_number_

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Chore (e.g., refactoring, build process, dependency updates)

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce._

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
